### PR TITLE
Allow transparent gifs to be generated

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,6 @@ export default async function petPetGif(
 	encoder.start();
 	encoder.setRepeat(0);
 	encoder.setDelay(options.delay);
-	encoder.setTransparent(null);
 
 	// Create canvas and its context
 	const canvas = createCanvas(options.resolution, options.resolution);

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export default async function petPetGif(
 	encoder.start();
 	encoder.setRepeat(0);
 	encoder.setDelay(options.delay);
+	encoder.setTransparent(0);
 
 	// Create canvas and its context
 	const canvas = createCanvas(options.resolution, options.resolution);


### PR DESCRIPTION
By changing ``encoder.setTransparent(null)`` to ``encoder.setTransparent(0)``, the gif no longer generates a black background by default.